### PR TITLE
Fix code scanning alert no. 10: Incomplete string escaping or encoding

### DIFF
--- a/Src/omBrowser/resources/pages/errorPageFunctions.js
+++ b/Src/omBrowser/resources/pages/errorPageFunctions.js
@@ -1,6 +1,6 @@
 function geturlparams( key )
 {
-	key = key.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
+	key = key.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regexS = "[\\#&]"+key+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );

--- a/Src/omBrowser/resources/pages/errorPageFunctions.js
+++ b/Src/omBrowser/resources/pages/errorPageFunctions.js
@@ -1,6 +1,6 @@
 function geturlparams( key )
 {
-	key = key.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+	key = key.replace(/([\\\[\]])/g, "\\$1");
 	var regexS = "[\\#&]"+key+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/winamp/security/code-scanning/10](https://github.com/cooljeanius/winamp/security/code-scanning/10)

To fix the problem, we need to ensure that all occurrences of the characters `[` and `]` in the `key` string are replaced. This can be achieved by using regular expressions with the global flag (`g`). Specifically, we will replace the current `replace` calls with ones that use regular expressions to match all occurrences of the characters.

- Change the `replace` method calls on line 3 to use regular expressions with the global flag.
- Ensure that both `[` and `]` are properly escaped in the `key` string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
