### PR TITLE
Fix code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/Src/Plugins/Library/ml_webdev/resources/pages/webdev.js
+++ b/Src/Plugins/Library/ml_webdev/resources/pages/webdev.js
@@ -1,6 +1,6 @@
 function GetUrlParam(name)
 {
-	name = name.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+	name = name.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regexS = "[\\?&]"+name+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );

--- a/Src/Plugins/Library/ml_webdev/resources/pages/webdev.js
+++ b/Src/Plugins/Library/ml_webdev/resources/pages/webdev.js
@@ -1,6 +1,6 @@
 function GetUrlParam(name)
 {
-	name = name.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
+	name = name.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regexS = "[\\?&]"+name+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/winamp/security/code-scanning/8](https://github.com/cooljeanius/winamp/security/code-scanning/8)

To fix the problem, we need to ensure that all occurrences of the characters `[` and `]` in the `name` parameter are properly escaped. This can be achieved by using a regular expression with the global flag (`g`). This ensures that every instance of the characters is replaced, not just the first one.

- Modify the `replace` method calls on line 3 to use regular expressions with the global flag.
- No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
