### PR TITLE
Fix code scanning alert no. 6: Incomplete string escaping or encoding

### DIFF
--- a/Src/Plugins/Library/ml_online/resources/pages/webdev.js
+++ b/Src/Plugins/Library/ml_online/resources/pages/webdev.js
@@ -1,6 +1,6 @@
 function GetUrlParam(name)
 {
-	name = name.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+	name = name.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regexS = "[\\?&]"+name+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );

--- a/Src/Plugins/Library/ml_online/resources/pages/webdev.js
+++ b/Src/Plugins/Library/ml_online/resources/pages/webdev.js
@@ -1,6 +1,6 @@
 function GetUrlParam(name)
 {
-	name = name.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
+	name = name.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regexS = "[\\?&]"+name+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/winamp/security/code-scanning/6](https://github.com/cooljeanius/winamp/security/code-scanning/6)

To fix the problem, we need to ensure that all occurrences of the characters `[` and `]` are replaced in the input string. This can be achieved by using a regular expression with the `g` flag, which stands for "global" and ensures that the replacement is applied to all matches in the string.

We will modify the `GetUrlParam` function to use regular expressions with the `g` flag for replacing `[` and `]`. This change will ensure that all occurrences of these characters are properly escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
