### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/Src/Components/wac_browser/resources/pages/errorPageFunctions.js
+++ b/Src/Components/wac_browser/resources/pages/errorPageFunctions.js
@@ -1,6 +1,6 @@
 function geturlparams( key )
 {
-	key = key.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
+	key = key.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regexS = "[\\#&]"+key+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );

--- a/Src/Components/wac_browser/resources/pages/errorPageFunctions.js
+++ b/Src/Components/wac_browser/resources/pages/errorPageFunctions.js
@@ -1,6 +1,6 @@
 function geturlparams( key )
 {
-	key = key.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+	key = key.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regexS = "[\\#&]"+key+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/winamp/security/code-scanning/2](https://github.com/cooljeanius/winamp/security/code-scanning/2)

To fix the problem, we need to ensure that all occurrences of the characters `[` and `]` in the `key` string are properly escaped. This can be achieved by using a regular expression with the global flag (`g`). Additionally, we should escape the backslash itself to prevent any potential issues with incomplete escaping.

- Replace the current `replace` method calls with regular expressions that include the global flag.
- Ensure that the backslash is also escaped correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
