### PR TITLE
Fix code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/Src/Components/wac_network/resources/pages/errorPageFunctions.js
+++ b/Src/Components/wac_network/resources/pages/errorPageFunctions.js
@@ -1,6 +1,6 @@
 function geturlparams( key )
 {
-	key = key.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
+	key = key.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regexS = "[\\#&]"+key+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );

--- a/Src/Components/wac_network/resources/pages/errorPageFunctions.js
+++ b/Src/Components/wac_network/resources/pages/errorPageFunctions.js
@@ -1,6 +1,6 @@
 function geturlparams( key )
 {
-	key = key.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+	key = key.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 	var regexS = "[\\#&]"+key+"=([^&#]*)";
 	var regex = new RegExp( regexS );
 	var results = regex.exec( window.location.href );


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/winamp/security/code-scanning/4](https://github.com/cooljeanius/winamp/security/code-scanning/4)

To fix the problem, we need to ensure that all occurrences of the characters `[` and `]` in the `key` string are replaced. This can be achieved by using a regular expression with the global flag (`g`). The `replace` method should be updated to use regular expressions instead of string literals.

- Update the `replace` method calls on line 3 to use regular expressions with the global flag.
- Ensure that both `[` and `]` are properly escaped in the regular expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
